### PR TITLE
Add FAPI 2 aware client assertion validation for private key JWT

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/pom.xml
@@ -132,6 +132,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.discovery</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -44,6 +44,8 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCache;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.cache.JWTCacheEntry;
@@ -67,6 +69,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -89,6 +92,7 @@ public class JWTValidator {
     public static final String PS = "PS";
     public static final String ES = "ES";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
+    private static final String PROP_TOKEN_EP = "OAuth2TokenEPUrl";
     private static final String PROP_ID_TOKEN_ISSUER_ID = "OAuth.OpenIDConnect.IDTokenIssuerID";
     private static final String FAPI_SIGNATURE_ALG_CONFIGURATION = "OAuth.OpenIDConnect.FAPI." +
             "AllowedSignatureAlgorithms.AllowedSignatureAlgorithm";
@@ -163,10 +167,20 @@ public class JWTValidator {
                 return false;
             }
 
-            /* A list of valid audiences (issuer identifier, token endpoint URL or pushed authorization request
-            endpoint URL) should be supported for PAR and not just a single valid audience.
-            https://datatracker.ietf.org/doc/html/rfc9126 */
-            List<String> acceptedAudienceList = getValidAudiences(tenantDomain, requestUrl);
+            List<String> acceptedAudienceList;
+            try {
+                if (FapiUtil.isFapiConformantApp(consumerKey, FapiProfileEnum.FAPI2_SECURITY)) {
+                    acceptedAudienceList = Collections.singletonList(IdentityUtil.getProperty(PROP_ID_TOKEN_ISSUER_ID));
+                } else {
+                /* A list of valid audiences (issuer identifier, token endpoint URL or pushed authorization request
+                endpoint URL) should be supported for PAR and not just a single valid audience.
+                https://datatracker.ietf.org/doc/html/rfc9126 */
+                    acceptedAudienceList = getValidAudiences(tenantDomain, requestUrl);
+                }
+            } catch (InvalidOAuthClientException e) {
+                throw new OAuthClientAuthnException("Error occurred while retrieving client information.",
+                        OAuth2ErrorCodes.INVALID_CLIENT);
+            }
 
             long expTime = 0;
             long issuedTime = 0;
@@ -187,7 +201,7 @@ public class JWTValidator {
             /* Check whether the request signing algorithm is an allowed algorithm as per the FAPI specification.
                https://openid.net/specs/openid-financial-api-part-2-1_0.html#algorithm-considerations */
             try {
-                if (OAuth2Util.isFapiConformantApp(consumerKey)) {
+                if (FapiUtil.isFapiConformantApp(consumerKey)) {
                     //   Mandating FAPI specified JWT signing algorithms.
                     List<String> fapiAllowedSigningAlgorithms = IdentityUtil
                             .getPropertyAsList(FAPI_SIGNATURE_ALG_CONFIGURATION);
@@ -216,7 +230,7 @@ public class JWTValidator {
             }
 
             //Validate signature validation, audience, nbf,exp time, jti.
-            if (!validateAudience(acceptedAudienceList, audience)
+            if (!validateAudienceFormat(audience, consumerKey) || !validateAudience(acceptedAudienceList, audience)
                     || !validateJWTWithExpTime(expirationTime, currentTimeInMillis, timeStampSkewMillis)
                     || !validateNotBeforeClaim(currentTimeInMillis, timeStampSkewMillis, nbf)
                     || !validateAgeOfTheToken(issuedAtTime, currentTimeInMillis, timeStampSkewMillis)
@@ -313,7 +327,34 @@ public class JWTValidator {
             log.debug("None of the audience values : " + audience + " matched the expected audiences : " +
                     expectedAudiences);
         }
-        throw new OAuthClientAuthnException("Failed to match audience values.", OAuth2ErrorCodes.INVALID_REQUEST);
+        throw new OAuthClientAuthnException("Failed to match audience values.", OAuth2ErrorCodes.INVALID_CLIENT);
+    }
+
+    /**
+     * Validate 'aud' claim format. Multiple audiences are not allowed in FAPI 2.0 compliant applications.
+     *
+     * @param audience - List of audience values in the 'aud' claim of the JWT.
+     * @param consumerKey - OAuth client id of the application.
+     * @return true if the audience format is valid.
+     *
+     * @throws OAuthClientAuthnException Throw OAuthClientAuthnException if the audience format is invalid.
+     */
+    private boolean validateAudienceFormat(List<String> audience, String consumerKey) throws OAuthClientAuthnException {
+
+        try {
+            if (FapiUtil.isFapiConformantApp(consumerKey, FapiProfileEnum.FAPI2_SECURITY)) {
+                if (audience.size() > 1) {
+                    log.debug("Multiple audience values in client assertion are not allowed for " +
+                            "FAPI 2.0 applications.");
+                    throw new OAuthClientAuthnException("Client assertion contains multiple audience values.",
+                            OAuth2ErrorCodes.INVALID_REQUEST);
+                }
+            }
+        } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+            throw new OAuthClientAuthnException("Error occurred while retrieving client information.",
+                    OAuth2ErrorCodes.INVALID_CLIENT);
+        }
+        return true;
     }
 
     // "REQUIRED. JWT ID. A unique identifier for the token, which can be used to prevent reuse of the token.
@@ -529,12 +570,12 @@ public class JWTValidator {
             FederatedAuthenticatorConfig oidcFedAuthn = IdentityApplicationManagementUtil
                     .getFederatedAuthenticator(residentIdP.getFederatedAuthenticatorConfigs(),
                             IdentityApplicationConstants.Authenticator.OIDC.NAME);
-            Property idpEntityId = IdentityApplicationManagementUtil.getProperty(oidcFedAuthn.getProperties(),
-                    IDP_ENTITY_ID);
+            Property tokenEndpointFromResidentIdp =
+                    IdentityApplicationManagementUtil.getProperty(oidcFedAuthn.getProperties(), PROP_TOKEN_EP);
             Property parEndpointFromResidentIdp = IdentityApplicationManagementUtil.getProperty(oidcFedAuthn
                     .getProperties(), Constants.OAUTH2_PAR_URL_REF);
-            if (idpEntityId != null) {
-                tokenEndpoint = idpEntityId.getValue();
+            if (tokenEndpointFromResidentIdp != null) {
+                tokenEndpoint = tokenEndpointFromResidentIdp.getValue();
             }
             if (parEndpointFromResidentIdp != null) {
                 parEndpoint = parEndpointFromResidentIdp.getValue();
@@ -570,6 +611,20 @@ public class JWTValidator {
         }
         if (StringUtils.isEmpty(parEndpoint)) {
             parEndpoint = IdentityUtil.getProperty(Constants.OAUTH2_PAR_URL_CONFIG);
+        }
+
+        /*
+         * https://www.rfc-editor.org/rfc/rfc9126.html#section-2
+         *
+         * "In order to facilitate interoperability, the authorization server MUST accept its issuer identifier,
+         * token endpoint URL, or pushed authorization request endpoint URL as values that identify it as an
+         * intended audience."
+         *
+         * As per the specification, when the incoming request is a PAR request, the server's issuer identifier
+         * is added to the list of acceptable audience values.
+         */
+        if (StringUtils.equals(requestUrl, parEndpoint)) {
+            validAudiences.add(IdentityUtil.getProperty(PROP_ID_TOKEN_ISSUER_ID));
         }
 
         if (StringUtils.isNotEmpty(validAudience)) {

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.discovery.DiscoveryUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -170,7 +171,7 @@ public class JWTValidator {
             List<String> acceptedAudienceList;
             try {
                 if (FapiUtil.isFapiConformantApp(consumerKey, FapiProfileEnum.FAPI2_SECURITY)) {
-                    acceptedAudienceList = Collections.singletonList(IdentityUtil.getProperty(PROP_ID_TOKEN_ISSUER_ID));
+                    acceptedAudienceList = Collections.singletonList(this.getIdTokenIssuer(tenantDomain));
                 } else {
                 /* A list of valid audiences (issuer identifier, token endpoint URL or pushed authorization request
                 endpoint URL) should be supported for PAR and not just a single valid audience.
@@ -213,9 +214,6 @@ public class JWTValidator {
             } catch (InvalidOAuthClientException e) {
                 throw new OAuthClientAuthnException("Could not find an existing app for clientId: " + consumerKey,
                         OAuth2ErrorCodes.INVALID_CLIENT);
-            } catch (IdentityOAuth2Exception e) {
-                throw new OAuthClientAuthnException("Error while obtaining the service provider for client_id: " +
-                        consumerKey, OAuth2ErrorCodes.SERVER_ERROR);
             }
 
             if (oAuthAppDO.isTokenEndpointAllowReusePvtKeyJwt() != null) {
@@ -623,8 +621,13 @@ public class JWTValidator {
          * As per the specification, when the incoming request is a PAR request, the server's issuer identifier
          * is added to the list of acceptable audience values.
          */
-        if (StringUtils.equals(requestUrl, parEndpoint)) {
-            validAudiences.add(IdentityUtil.getProperty(PROP_ID_TOKEN_ISSUER_ID));
+        try {
+            if (StringUtils.equals(requestUrl, parEndpoint)) {
+                validAudiences.add(this.getIdTokenIssuer(tenantDomain));
+            }
+        } catch (InvalidOAuthClientException e) {
+            throw new OAuthClientAuthnException("Error while loading the issuer URL for tenant: " + tenantDomain,
+                    OAuth2ErrorCodes.INVALID_REQUEST);
         }
 
         if (StringUtils.isNotEmpty(validAudience)) {
@@ -881,4 +884,17 @@ public class JWTValidator {
         return configuredSigningAlgorithms;
     }
 
+    private String getIdTokenIssuer(final String tenantDomain) throws InvalidOAuthClientException {
+
+        if (DiscoveryUtil.isUseEntityIdAsIssuerInOidcDiscovery()) {
+            try {
+                return OAuth2Util.getIdTokenIssuer(tenantDomain);
+            } catch (IdentityOAuth2Exception e) {
+                throw new InvalidOAuthClientException(String.format("Error while retrieving OIDC Id token issuer " +
+                        "value for tenant domain: %s", tenantDomain), e);
+            }
+        } else {
+            return OAuth2Util.getIDTokenIssuer();
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -342,8 +342,9 @@ public class JWTValidator {
         try {
             if (FapiUtil.isFapiConformantApp(consumerKey, FapiProfileEnum.FAPI2_SECURITY)) {
                 if (audience.size() > 1) {
-                    log.debug("Multiple audience values in client assertion are not allowed for " +
-                            "FAPI 2.0 applications.");
+                    if (log.isDebugEnabled()) {
+                        log.debug("Invalid FAPI 2.0 client assertion: multiple audiences. clientID: " + consumerKey);
+                    }
                     throw new OAuthClientAuthnException("Client assertion contains multiple audience values.",
                             OAuth2ErrorCodes.INVALID_REQUEST);
                 }

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -18,12 +18,14 @@
 
 package org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -32,6 +34,7 @@ import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
@@ -40,6 +43,7 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.JWT
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.idp.mgt.internal.IdpMgtServiceComponentHolder;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -151,14 +155,25 @@ public class PrivateKeyJWTClientAuthenticatorTest {
         Mockito.when(httpServletRequest.getRequestURL())
                 .thenReturn(new StringBuffer("http://localhost:9443/oauth2/token"));
 
-        try {
-            privateKeyJWTClientAuthenticator.authenticateClient(httpServletRequest, bodyContent,
-                    oAuthClientAuthnContext);
-            assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
-                    Constants.AUTHENTICATOR_TYPE_PARAM));
-        } catch (OAuthClientAuthnException e) {
-            assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
-                    Constants.AUTHENTICATOR_TYPE_PARAM));
+        OAuthAppDO mockAppDO = new OAuthAppDO();
+        mockAppDO.setOauthConsumerKey(TEST_CLIENT_ID_1);
+        AuthenticatedUser appOwner = new AuthenticatedUser();
+        appOwner.setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+        mockAppDO.setAppOwner(appOwner);
+
+        try (MockedStatic<OAuth2Util> mockedOAuth2Util = Mockito.mockStatic(OAuth2Util.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(Mockito.anyString()))
+                    .thenReturn(mockAppDO);
+            try {
+                privateKeyJWTClientAuthenticator.authenticateClient(httpServletRequest, bodyContent,
+                        oAuthClientAuthnContext);
+                assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
+                        Constants.AUTHENTICATOR_TYPE_PARAM));
+            } catch (OAuthClientAuthnException e) {
+                assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
+                        Constants.AUTHENTICATOR_TYPE_PARAM));
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/util/JWTTestUtil.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/util/JWTTestUtil.java
@@ -132,6 +132,34 @@ public class JWTTestUtil {
         return signJWTWithRSA(jwtClaimsSet, privateKey);
     }
 
+    public static String buildJWT(String issuer, String subject, String jti, List<String> audiences,
+                                  String algorithm, Key privateKey, long notBeforeMillis)
+            throws IdentityOAuth2Exception {
+
+        long lifetimeInMillis = 3600 * 1000;
+        long curTimeInMillis = Calendar.getInstance().getTimeInMillis();
+
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.issuer(issuer);
+        jwtClaimsSetBuilder.subject(subject);
+        jwtClaimsSetBuilder.audience(audiences);
+        jwtClaimsSetBuilder.jwtID(jti);
+        jwtClaimsSetBuilder.expirationTime(new Date(curTimeInMillis + lifetimeInMillis));
+        jwtClaimsSetBuilder.issueTime(new Date(curTimeInMillis));
+
+        if (notBeforeMillis > 0) {
+            jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis + notBeforeMillis));
+        }
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+        if (JWSAlgorithm.NONE.getName().equals(algorithm)) {
+            return new PlainJWT(jwtClaimsSet).serialize();
+        } else if (JWSAlgorithm.RS512.getName().equals(algorithm)) {
+            return signJWTWithRSA512(jwtClaimsSet, privateKey);
+        }
+
+        return signJWTWithRSA(jwtClaimsSet, privateKey);
+    }
+
     public static String buildJWT(String issuer, String subject, String jti, String audience, String algorythm,
                                   Key privateKey, long notBeforeMillis, long lifetimeInMillis, long issuedTime)
             throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -37,7 +37,10 @@ import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
@@ -66,6 +69,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.REJECT_BEFORE_IN_MINUTES;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.buildJWT;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.getJWTValidator;
@@ -313,6 +318,68 @@ public class JWTValidatorTest {
 
     }
 
+    @Test
+    public void testValidateFapi2TokenWithIssuerAudience() throws Exception {
+
+        Key key = clientKeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
+        String jwt = buildJWT(TEST_FAPI_CLIENT_ID_1, TEST_FAPI_CLIENT_ID_1, "3024", ID_TOKEN_ISSUER_ID,
+                "RS512", key, 0);
+
+        mockApplicationManagementService();
+        try (MockedStatic<IdentityProviderManager> mockedIdentityProviderManager = mockIdentityProviderManager();
+             MockedStatic<FapiUtil> mockedFapiUtil = mockStatic(FapiUtil.class);
+             MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class,
+                     Mockito.CALLS_REAL_METHODS)) {
+            mockedFapiUtil.when(() -> FapiUtil.isFapiConformantApp(TEST_FAPI_CLIENT_ID_1,
+                    FapiProfileEnum.FAPI2_SECURITY)).thenReturn(true);
+            mockedFapiUtil.when(() -> FapiUtil.isFapiConformantApp(TEST_FAPI_CLIENT_ID_1)).thenReturn(true);
+            mockedIdentityUtil.when(() -> IdentityUtil.getProperty("OAuth.OpenIDConnect.IDTokenIssuerID"))
+                    .thenReturn(ID_TOKEN_ISSUER_ID);
+            mockedIdentityUtil.when(() -> IdentityUtil.getPropertyAsList(
+                    "OAuth.OpenIDConnect.FAPI.AllowedSignatureAlgorithms.AllowedSignatureAlgorithm"))
+                    .thenReturn(Arrays.asList("PS256", "ES256", "RS512"));
+
+            checkIfTenantIdColumnIsAvailableInIdnOidcAuthTable();
+            JWTValidator jwtValidator = getJWTValidator(new Properties());
+
+            assertTrue(jwtValidator.isValidAssertion(SignedJWT.parse(jwt)),
+                    "FAPI 2 client assertions with issuer audience should pass validation.");
+        }
+    }
+
+    @Test
+    public void testRejectMultipleAudiencesForFapi2Token() throws Exception {
+
+        Key key = clientKeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
+        String jwt = buildJWT(TEST_FAPI_CLIENT_ID_1, TEST_FAPI_CLIENT_ID_1, "3025",
+                Arrays.asList(ID_TOKEN_ISSUER_ID, PAR_ENDPOINT), "RS512", key, 0);
+
+        mockApplicationManagementService();
+        try (MockedStatic<IdentityProviderManager> mockedIdentityProviderManager = mockIdentityProviderManager();
+             MockedStatic<FapiUtil> mockedFapiUtil = mockStatic(FapiUtil.class);
+             MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class,
+                     Mockito.CALLS_REAL_METHODS)) {
+            mockedFapiUtil.when(() -> FapiUtil.isFapiConformantApp(TEST_FAPI_CLIENT_ID_1,
+                    FapiProfileEnum.FAPI2_SECURITY)).thenReturn(true);
+            mockedFapiUtil.when(() -> FapiUtil.isFapiConformantApp(TEST_FAPI_CLIENT_ID_1)).thenReturn(true);
+            mockedIdentityUtil.when(() -> IdentityUtil.getProperty("OAuth.OpenIDConnect.IDTokenIssuerID"))
+                    .thenReturn(ID_TOKEN_ISSUER_ID);
+            mockedIdentityUtil.when(() -> IdentityUtil.getPropertyAsList(
+                    "OAuth.OpenIDConnect.FAPI.AllowedSignatureAlgorithms.AllowedSignatureAlgorithm"))
+                    .thenReturn(Arrays.asList("PS256", "ES256", "RS512"));
+
+            checkIfTenantIdColumnIsAvailableInIdnOidcAuthTable();
+            JWTValidator jwtValidator = getJWTValidator(new Properties());
+
+            try {
+                jwtValidator.isValidAssertion(SignedJWT.parse(jwt));
+                fail("FAPI 2 client assertions with multiple audience values should fail validation.");
+            } catch (OAuthClientAuthnException e) {
+                assertEquals(e.getMessage(), "Client assertion contains multiple audience values.");
+            }
+        }
+    }
+
     @Test(dependsOnMethods = "testValidateToken")
     public void testValidateTokenSignedByHmac() throws Exception {
 
@@ -323,4 +390,26 @@ public class JWTValidatorTest {
                 "Jzb21lLWF1ZGllbmNlIl19.m0RrVUrZHr1M7R4I_4dzpoWD8jNA2fKkOadEsFg9Wj4";
         SignedJWT signedJWT = SignedJWT.parse(hsSignedJWT);
     }
+
+        private void mockApplicationManagementService() throws Exception {
+
+                ServiceProvider mockedServiceProvider = Mockito.mock(ServiceProvider.class);
+                when(mockedServiceProvider.getCertificateContent()).thenReturn(CERTIFICATE);
+                ApplicationManagementService mockedApplicationManagementService =
+                                Mockito.mock(ApplicationManagementService.class);
+                when(mockedApplicationManagementService.getServiceProviderByClientId(anyString(), anyString(),
+                                anyString())).thenReturn(mockedServiceProvider);
+                OAuth2ServiceComponentHolder.setApplicationMgtService(mockedApplicationManagementService);
+        }
+
+        private MockedStatic<IdentityProviderManager> mockIdentityProviderManager() throws Exception {
+
+                MockedStatic<IdentityProviderManager> mockedIdentityProviderManager = 
+                        mockStatic(IdentityProviderManager.class);
+                IdentityProviderManager mockedIdpManager = Mockito.mock(IdentityProviderManager.class);
+                IdentityProvider mockedIdp = Mockito.mock(IdentityProvider.class);
+                when(mockedIdpManager.getResidentIdP(anyString())).thenReturn(mockedIdp);
+                mockedIdentityProviderManager.when(IdentityProviderManager::getInstance).thenReturn(mockedIdpManager);
+                return mockedIdentityProviderManager;
+        }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,11 @@
                 <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
                 <version>${carbon.identity.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+                <artifactId>org.wso2.carbon.identity.discovery</artifactId>
+                <version>${identity.inbound.auth.oauth.version}</version>
+            </dependency>
             <!--Test Dependencies-->
             <dependency>
                 <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
         <carbon.identity.version>7.10.119</carbon.identity.version>
         <carbon.identity.application.common.version>7.8.506</carbon.identity.application.common.version>
         <carbon.utils.version>4.12.22</carbon.utils.version>
-        <identity.inbound.auth.oauth.version>7.0.286</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.5.49</identity.inbound.auth.oauth.version>
         <org.wso2.carbon.identity.core.version>7.10.119</org.wso2.carbon.identity.core.version>
         <org.wso2.carbon.database.utils.version>2.0.7</org.wso2.carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
Introduce FAPI 2-compatible validation behavior for `private_key_jwt` client authentication in the JWT handler.
This change updates client assertion validation so that FAPI-conformant applications, especially FAPI 2 Security profile applications, are validated against the correct audience and format requirements.



## Goals
- Support profile-aware FAPI validation for client assertions.
- Enforce stricter audience handling required by FAPI 2 Security.
- Align accepted audience values with issuer, token endpoint, and PAR endpoint expectations.
- Improve interoperability for PAR requests while preserving existing behavior for non-FAPI 2 applications.

## Approach
This change updates `JWTValidator` to introduce FAPI-aware assertion validation logic.

Key changes:
- Use `FapiUtil` and `FapiProfileEnum` to detect FAPI-conformant applications and FAPI 2 Security profile applications.
- For FAPI 2 Security applications, validate the client assertion audience against the issuer identifier instead of the broader audience set used for non-FAPI 2 flows.
- Reject multiple `aud` claim values for FAPI 2 Security applications.
- Use the resident IdP `OAuth2TokenEPUrl` property when resolving valid token audiences.
- Add the issuer identifier as an accepted audience for PAR requests in line with RFC 9126 guidance.
- Return `invalid_client` for audience mismatch conditions where appropriate.

## User stories
- As an API consumer using FAPI 2 Security, I need client assertion validation to follow FAPI 2 audience requirements.
- As a platform operator, I need FAPI validation behavior to be profile-aware without breaking existing non-FAPI 2 clients.
- As a client using PAR, I need the server to accept interoperable audience values defined by the specification.

## Release note
Added FAPI 2-aware `private_key_jwt` client assertion validation, including stricter audience validation and profile-specific handling for FAPI-compliant applications.

## Documentation
N/A - This change is an internal validation behavior update in the JWT client authentication handler. Product documentation should only be updated if FAPI 2 configuration and audience expectations are being documented externally.

## Training
N/A - No training content impact identified.

## Certification
N/A - No certification exam impact identified.

## Marketing
N/A - No marketing content impact identified.

## Automation tests
- Unit tests
  > No new unit tests were included in this change set. Recommend adding or running coverage for:
  > - FAPI 2 Security client assertion with a single issuer audience
  > - rejection of multiple audience values for FAPI 2 Security
  > - PAR audience validation including issuer acceptance
- Integration tests
  > No integration test changes were included in this change set.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? not verified as part of this PR drafting exercise
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - No sample changes are required for this update.

## Related PRs
N/A

## Migrations (if applicable)
No migration steps are expected. Existing behavior is preserved for non-FAPI 2 applications, while FAPI 2 Security applications will now be validated with stricter audience requirements.

## Test environment
Not verified as part of this analysis.
Suggested to update with actual validation details before opening the PR:
- JDK version used for validation
- Operating system
- Any relevant Identity Server / OAuth component versions

## Learning
This change aligns audience validation with FAPI and PAR expectations, especially:
- FAPI 2 Security profile restrictions on client assertion audience format
- RFC 9126 interoperability guidance for accepted PAR audiences