### PR TITLE
Fix private_key_jwt failing when signing algorithm is configured as SHA256withRSA

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -839,6 +839,11 @@ public class JWTValidator {
 
     /**
      * Validate whether the request signing algorithm is configured for the application.
+     * <p>
+     * The algorithm configured for the application can be stored either as a JWS algorithm name (e.g. PS256) or as
+     * a Java signature algorithm name (e.g. SHA256withRSA), while the request always carries the JWS algorithm name.
+     * Hence the configured value is compared against the request value both directly and after mapping it to its
+     * equivalent JWS algorithm name.
      *
      * @param requestSigningAlgorithm     The request signed algorithm.
      * @param clientId                    Client ID of the application.
@@ -851,14 +856,39 @@ public class JWTValidator {
         //   Obtain the signing algorithm configured for the application.
         List<String> configuredSigningAlgorithms = getConfiguredSigningAlgorithm(clientId);
         //  Validate whether the JWT signing algorithm is configured for the application.
-        if (configuredSigningAlgorithms.isEmpty() || configuredSigningAlgorithms.contains(requestSigningAlgorithm)) {
+        if (configuredSigningAlgorithms.isEmpty()) {
             return true;
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("JWT signed algorithm: " + requestSigningAlgorithm + " does not match with the " +
-                        "configured algorithms: " + configuredSigningAlgorithms);
+        }
+        for (String configuredSigningAlgorithm : configuredSigningAlgorithms) {
+            if (StringUtils.equals(configuredSigningAlgorithm, requestSigningAlgorithm)
+                    || StringUtils.equals(mapToJWSAlgorithmName(configuredSigningAlgorithm),
+                    requestSigningAlgorithm)) {
+                return true;
             }
-            return false;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("JWT signed algorithm: " + requestSigningAlgorithm + " does not match with the " +
+                    "configured algorithms: " + configuredSigningAlgorithms);
+        }
+        return false;
+    }
+
+    /**
+     * Map a signature algorithm name configured for the application to its equivalent JWS algorithm name.
+     *
+     * @param signatureAlgorithm Signature algorithm name configured for the application.
+     * @return The equivalent JWS algorithm name, or null if the value cannot be mapped.
+     */
+    private String mapToJWSAlgorithmName(String signatureAlgorithm) {
+
+        try {
+            return OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(signatureAlgorithm).getName();
+        } catch (IdentityOAuth2Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Unable to map the configured signature algorithm: " + signatureAlgorithm +
+                        " to a JWS algorithm name.", e);
+            }
+            return null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/PrivateKeyJWTClientAuthenticatorTest.java
@@ -22,10 +22,18 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -38,12 +46,14 @@ import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.dao.JWTAuthenticationConfigurationDAO;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.internal.IdpMgtServiceComponentHolder;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -74,6 +84,10 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
         injectToSingletons = {JWTServiceComponent.class})
 @WithKeyStore
 public class PrivateKeyJWTClientAuthenticatorTest {
+
+    private static final String INVALID_SIGNATURE_ALGORITHM_ERROR =
+            "Signature algorithm used in the request is invalid.";
+    private static final String PROP_TOKEN_EP = "OAuth2TokenEPUrl";
 
     PrivateKeyJWTClientAuthenticator privateKeyJWTClientAuthenticator;
     HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
@@ -173,6 +187,103 @@ public class PrivateKeyJWTClientAuthenticatorTest {
             } catch (OAuthClientAuthnException e) {
                 assertEquals(Constants.AUTHENTICATOR_TYPE_PK_JWT, oAuthClientAuthnContext.getParameter(
                         Constants.AUTHENTICATOR_TYPE_PARAM));
+            }
+        }
+    }
+
+    @DataProvider(name = "provideConfiguredSignatureAlgorithm")
+    public Object[][] provideConfiguredSignatureAlgorithm() {
+
+        return new Object[][]{
+                //   The Java signature algorithm name of RS256, as offered by the Console.
+                {"SHA256withRSA", "3040"},
+                //   The JWS algorithm name of the same algorithm.
+                {"RS256", "3041"},
+        };
+    }
+
+    /**
+     * A client assertion signed with RS256 must not be rejected for an invalid signature algorithm when the
+     * application is configured with an algorithm that is equivalent to RS256, regardless of whether it is stored
+     * using the Java signature algorithm name or the JWS algorithm name.
+     */
+    @Test(dataProvider = "provideConfiguredSignatureAlgorithm")
+    public void testAssertionIsNotRejectedForEquivalentSignatureAlgorithm(String configuredSignatureAlgorithm,
+                                                                          String jti) throws Exception {
+
+        Map<String, List> bodyContent = new HashMap<>();
+        List<String> assertionType = new ArrayList<>();
+        assertionType.add(OAUTH_JWT_BEARER_GRANT_TYPE);
+        List<String> assertion = new ArrayList<>();
+        //   buildJWT signs with RS256 unless RS512 or none is requested.
+        assertion.add(buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, jti, audience, "RS256", key1, 0));
+        bodyContent.put(OAUTH_JWT_ASSERTION, assertion);
+        bodyContent.put(OAUTH_JWT_ASSERTION_TYPE, assertionType);
+
+        RealmService realmService = IdentityTenantUtil.getRealmService();
+        UserRealm userRealm = realmService.getTenantUserRealm(SUPER_TENANT_ID);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+        JWTServiceDataHolder.getInstance().setRealmService(realmService);
+        IdpMgtServiceComponentHolder.getInstance().setRealmService(realmService);
+
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
+        jwtClientAuthenticatorConfig.setEnableTokenReuse(true);
+        JWTAuthenticationConfigurationDAO mockDAO = Mockito.mock(JWTAuthenticationConfigurationDAO.class);
+        Mockito.when(mockDAO.getPrivateKeyJWTClientAuthenticationConfigurationByTenantDomain(Mockito.anyString()))
+                .thenReturn(jwtClientAuthenticatorConfig);
+        JWTServiceDataHolder.getInstance().setJwtAuthenticationConfigurationDAO(mockDAO);
+        Mockito.when(httpServletRequest.getRequestURL())
+                .thenReturn(new StringBuffer("http://localhost:9443/oauth2/token"));
+
+        OAuthAppDO mockAppDO = new OAuthAppDO();
+        mockAppDO.setOauthConsumerKey(TEST_CLIENT_ID_1);
+        mockAppDO.setTokenEndpointAuthSignatureAlgorithm(configuredSignatureAlgorithm);
+        AuthenticatedUser appOwner = new AuthenticatedUser();
+        appOwner.setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+        mockAppDO.setAppOwner(appOwner);
+
+        /* The audience of the assertion is validated against the token endpoint of the resident IdP before the
+           signature algorithm is validated, so the resident IdP has to resolve for the check to be reached. */
+        Property tokenEndpoint = new Property();
+        tokenEndpoint.setName(PROP_TOKEN_EP);
+        tokenEndpoint.setValue(audience);
+        FederatedAuthenticatorConfig oidcConfig = new FederatedAuthenticatorConfig();
+        oidcConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
+        oidcConfig.setProperties(new Property[]{tokenEndpoint});
+        IdentityProvider residentIdp = new IdentityProvider();
+        residentIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{oidcConfig});
+        IdentityProviderManager mockIdpManager = Mockito.mock(IdentityProviderManager.class);
+        Mockito.when(mockIdpManager.getResidentIdP(Mockito.anyString())).thenReturn(residentIdp);
+
+        /* The signature is verified after the algorithm check. No certificate is configured on the service provider
+           here, so verification falls back to the tenant keystore. */
+        ServiceProvider serviceProvider = Mockito.mock(ServiceProvider.class);
+        Mockito.when(serviceProvider.getCertificateContent()).thenReturn(null);
+        Mockito.when(serviceProvider.getSpProperties()).thenReturn(new ServiceProviderProperty[0]);
+        ApplicationManagementService applicationMgtService = Mockito.mock(ApplicationManagementService.class);
+        Mockito.when(applicationMgtService.getServiceProviderByClientId(Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyString())).thenReturn(serviceProvider);
+        OAuth2ServiceComponentHolder.setApplicationMgtService(applicationMgtService);
+
+        try (MockedStatic<OAuth2Util> mockedOAuth2Util = Mockito.mockStatic(OAuth2Util.class,
+                     Mockito.CALLS_REAL_METHODS);
+             MockedStatic<IdentityProviderManager> mockedIdpManagerStatic =
+                     Mockito.mockStatic(IdentityProviderManager.class)) {
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(Mockito.anyString()))
+                    .thenReturn(mockAppDO);
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(Mockito.anyString(),
+                    Mockito.anyString())).thenReturn(mockAppDO);
+            mockedIdpManagerStatic.when(IdentityProviderManager::getInstance).thenReturn(mockIdpManager);
+            try {
+                //   A dedicated context per invocation, since authenticateClient cannot overwrite an existing key.
+                privateKeyJWTClientAuthenticator.authenticateClient(httpServletRequest, bodyContent,
+                        new OAuthClientAuthnContext());
+            } catch (OAuthClientAuthnException e) {
+                /* Validation can still fail for later reasons in this test setup, such as the signature itself not
+                   being verifiable, but it must never fail because the signature algorithm was considered invalid. */
+                Assert.assertNotEquals(e.getMessage(), INVALID_SIGNATURE_ALGORITHM_ERROR,
+                        "A client assertion signed with RS256 was rejected while the application was configured "
+                                + "with the equivalent algorithm: " + configuredSignatureAlgorithm);
             }
         }
     }


### PR DESCRIPTION
## Purpose

Resolves wso2/product-is#28306

`private_key_jwt` client authentication fails permanently when an application's **Signing algorithm** is set to `SHA256withRSA`. The token request is rejected with:

```json
{"error_description":"Signature algorithm used in the request is invalid.","error":"invalid_client"}
```

`JWTValidator.isValidSignatureAlgorithm` compares the algorithm configured on the application to the JWS `alg` header of the incoming assertion as a plain string:

```java
if (configuredSigningAlgorithms.isEmpty() || configuredSigningAlgorithms.contains(requestSigningAlgorithm)) {
```

`getConfiguredSigningAlgorithm` returns the value exactly as stored (`OAuthAppDO.getTokenEndpointAuthSignatureAlgorithm()`), and the request always carries the JWS name. The Console offers `SHA256withRSA` for RS256, so the stored value never equals `RS256` and the check can never pass.

Of the values the Console offers for this field (`PS256`, `ES256`, `ES384`, `RS384`, `SHA256withRSA`), `SHA256withRSA` is the only one not already in JWS form. The other four work only because their stored name happens to equal the JWS name. Clearing the field is the only workaround, and that disables the check entirely, since an empty list returns `true`.

## Goals

Accept a configured algorithm that is equivalent to the algorithm the assertion was signed with, whether it is stored as a JWS algorithm name or as a Java signature algorithm name. Existing applications already stored with `SHA256withRSA` are fixed without any reconfiguration.

## Approach

Compare the configured value against the request value both directly and after mapping it through `OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm`. An unmappable configured value maps to `null`, is logged at debug level, and falls through to the mismatch path, so an unknown value is still rejected.

This mirrors the handling already used for request objects in [`RequestObjectValidatorUtil`](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java#L87-L101), which compares against both the stored name and its mapped name.

### Notes for reviewers

Two related gaps are **not** addressed here, since both are separate changes in `identity-inbound-auth-oauth`. Raising them for visibility:

1. `RS256` cannot be stored at all. `OAuthAdminServiceImpl.filterSignatureAlgorithms` validates against the raw `identity.xml` list, so a PUT with `RS256` fails with `'RS256' Signing Algorithm is not allowed.` `OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm` also only accepts the Java name for RS256, unlike the `RS384`, `ES256`, `ES384` and `PS256` branches which accept both forms.
2. DCR is affected the same way. `token_endpoint_auth_signing_alg` is a JWS algorithm name per RFC 7591, but registration rejects `RS256` and accepts only `SHA256withRSA` — after which the client can never authenticate.

Also note that `JWTValidatorTest` is commented out of `src/test/resources/testng.xml` and 22 of its 28 tests currently fail on `main`, so the new test was added to `PrivateKeyJWTClientAuthenticatorTest`, which the suite does run. Re-enabling `JWTValidatorTest` looks worth a separate issue.

## Release note

Fixed `private_key_jwt` client authentication failing when the application's client-assertion signing algorithm is configured as `SHA256withRSA`.

## Documentation

N/A — restores the documented behaviour of an existing configuration option; no user-facing change in configuration or API.

## Training

N/A

## Certification

N/A — bug fix in existing signature algorithm validation, no impact on exam content.

## Marketing

N/A

## Automation tests

 - Unit tests

   Added `testAssertionIsNotRejectedForEquivalentSignatureAlgorithm` to `PrivateKeyJWTClientAuthenticatorTest`, covering an RS256-signed assertion against an application configured with `SHA256withRSA` and with `RS256`.

   Verified the test is a real regression test:
   - Without the source change: 1 failure, the `SHA256withRSA` row, asserting on the exact `Signature algorithm used in the request is invalid.` message. The `RS256` row passes, as it needs no fix.
   - With the source change: 25/25 pass, checkstyle clean.

 - Integration tests

   N/A

## Manual testing

Reproduced and verified against a local pack, on the shipped `org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt` 2.6.8.

1. Created an OIDC app with `client_credentials`, `private_key_jwt`, a PEM certificate, and `tokenEndpointAuthSigningAlg` set to `SHA256withRSA`.
2. Posted an RS256-signed client assertion to `/oauth2/token`. Rejected with `invalid_client` / `Signature algorithm used in the request is invalid.`
3. Cleared the signing algorithm via the OIDC inbound-protocol PUT. The same assertion then succeeded, confirming the algorithm check is the only thing failing.

## Security checks

 - [x] Followed secure coding standards in [http://wso2.com/technical-reports/wso2-secure-engineering-guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? yes
 - [ ] Ran FindSecurityBugs plugin and verified report? not run locally — relying on the CI security scan
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Validation is not weakened: a configured algorithm is still required to match the assertion, and an unrecognised configured value is still rejected. The change only additionally accepts the equivalent name for the same algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
