### PR TITLE
Resolve OAuth application within the organization hierarchy

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -28,6 +28,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -442,8 +443,19 @@ public class JWTValidator {
         OAuthAppDO oAuthAppDO = null;
         String message = String.format("Error while retrieving OAuth application with provided JWT information with " +
                 "subject '%s' ", jwtSubject);
+
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
         try {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientId(jwtSubject);
+            if (StringUtils.isNotEmpty(accessingOrgId)) {
+                /*
+                 Organization qualified request. The login tenant is the parent organization, not the one the
+                 application resides in, so the application has to be resolved within the organization hierarchy.
+                */
+                oAuthAppDO = OAuth2Util.getAppInformationFromOrgHierarchy(jwtSubject, accessingOrgId);
+            } else {
+                oAuthAppDO = OAuth2Util.getAppInformationByClientId(jwtSubject);
+            }
             if (oAuthAppDO == null) {
                 logAndThrowException(message);
             }
@@ -636,6 +648,21 @@ public class JWTValidator {
         }
         validAudiences.add(tokenEndpoint);
         validAudiences.add(parEndpoint);
+
+        String appResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
+        if (!StringUtils.isBlank(appResidentOrgId)) {
+            try {
+                // Format of https://<host>/t/<root-tenant-domain>/o/<accessing-org-id>/oauth2/token
+                tokenEndpoint = ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
+                validAudiences.add(tokenEndpoint);
+                parEndpoint = ServiceURLBuilder.create().addPath(OAUTH2_PAR_EP_URL).build().getAbsolutePublicURL();
+                validAudiences.add(parEndpoint);
+            } catch (URLBuilderException e) {
+                throw new OAuthClientAuthnException(e.getMessage(), OAuth2ErrorCodes.INVALID_REQUEST, e);
+            }
+        }
+
         return validAudiences;
     }
 
@@ -872,8 +899,19 @@ public class JWTValidator {
 
         List<String> configuredSigningAlgorithms = new ArrayList<>();
         String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
         try {
-            OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, tenantDomain);
+            OAuthAppDO oAuthAppDO;
+            if (StringUtils.isNotEmpty(accessingOrgId)) {
+                /*
+                 Organization qualified request. The resolved tenant domain is the parent organization, not the
+                 one the application resides in, so resolve within the organization hierarchy.
+                */
+                oAuthAppDO = OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId);
+            } else {
+                oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, tenantDomain);
+            }
             String tokenEndpointAuthSignatureAlgorithm = oAuthAppDO.getTokenEndpointAuthSignatureAlgorithm();
             if (StringUtils.isNotBlank(tokenEndpointAuthSignatureAlgorithm)) {
                 configuredSigningAlgorithms = Arrays.asList(tokenEndpointAuthSignatureAlgorithm);

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/main/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidator.java
@@ -445,7 +445,7 @@ public class JWTValidator {
                 "subject '%s' ", jwtSubject);
 
         String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
+                .getAccessingOrganizationId();
         try {
             if (StringUtils.isNotEmpty(accessingOrgId)) {
                 /*
@@ -649,9 +649,9 @@ public class JWTValidator {
         validAudiences.add(tokenEndpoint);
         validAudiences.add(parEndpoint);
 
-        String appResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
-        if (!StringUtils.isBlank(appResidentOrgId)) {
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getAccessingOrganizationId();
+        if (!StringUtils.isBlank(accessingOrgId)) {
             try {
                 // Format of https://<host>/t/<root-tenant-domain>/o/<accessing-org-id>/oauth2/token
                 tokenEndpoint = ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
@@ -900,7 +900,7 @@ public class JWTValidator {
         List<String> configuredSigningAlgorithms = new ArrayList<>();
         String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
+                .getAccessingOrganizationId();
         try {
             OAuthAppDO oAuthAppDO;
             if (StringUtils.isNotEmpty(accessingOrgId)) {

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -147,7 +147,7 @@ public class JWTValidatorTest {
                     "W/bQM+jWUllR4Qpwx6R1mVy3pFRl0+4npUr17XOGEoP9Xm/5kMvsiNOTqryR5p3xEPBQcXBJES8K\n" +
                     "oQon6A==";
 
-    private String previousAppResidentOrgId;
+    private String previousAccessingOrgId;
 
     /*
      Tests that exercise organization qualified behaviour mutate the thread local carbon context. Snapshot it before
@@ -156,15 +156,15 @@ public class JWTValidatorTest {
     @BeforeMethod
     public void captureCarbonContext() {
 
-        previousAppResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
+        previousAccessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getAccessingOrganizationId();
     }
 
     @AfterMethod
     public void restoreCarbonContext() {
 
         PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .setApplicationResidentOrganizationId(previousAppResidentOrgId);
+                .setAccessingOrganizationId(previousAccessingOrgId);
     }
 
     @BeforeClass

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnException;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
@@ -45,6 +46,7 @@ import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceComponent;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.internal.JWTServiceDataHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.testutil.ReadCertStoreSampleUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.internal.IdpMgtServiceComponentHolder;
@@ -52,6 +54,8 @@ import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -59,16 +63,20 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.REJECT_BEFORE_IN_MINUTES;
@@ -91,6 +99,8 @@ public class JWTValidatorTest {
     public static final String TEST_FAPI_CLIENT_ID_1 = "KrVLov4Bl3natUksF2HmWsdw684b";
     public static final String TEST_FAPI_CLIENT_ID_2 = "KrVLov4Bl3natUksF2HmWsdw684c";
     public static final String TEST_SECRET_1 = "testSecret1";
+    public static final String TEST_ORG_ID = "4dcedae8-5e1a-4812-abd0-4b034d40ad75";
+    public static final String RS256 = "RS256";
     public static final String VALID_ISSUER_VAL = "valid-issuer";
     public static final String VALID_ISSUER = "ValidIssuer";
     public static final String VALID_AUDIENCE = "ValidAudience";
@@ -389,6 +399,121 @@ public class JWTValidatorTest {
                 "JWTG92NEJsM25hdFVrc0YySG1Xc2R3Njg0YSIsImp0aSI6MTAwOCwiZXhwIjoiMjU1NDQ0MDEzMjAwMCIsImF1ZCI6Wy" +
                 "Jzb21lLWF1ZGllbmNlIl19.m0RrVUrZHr1M7R4I_4dzpoWD8jNA2fKkOadEsFg9Wj4";
         SignedJWT signedJWT = SignedJWT.parse(hsSignedJWT);
+    }
+
+    /**
+     * On an organization qualified token request (/t/{tenant}/o/{orgId}/oauth2/token) the login tenant is the
+     * parent organization, so the application must be resolved through the organization hierarchy. Resolving it
+     * against the login tenant misses the application and surfaces as
+     * "Error while retrieving OAuth application with provided JWT information".
+     */
+    @Test
+    public void testGetOAuthAppDOResolvesThroughOrgHierarchyForOrgQualifiedRequest() throws Exception {
+
+        JWTValidator jwtValidator = getJWTValidator(new Properties());
+        OAuthAppDO expectedApp = new OAuthAppDO();
+        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
+        try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID))
+                    .thenReturn(expectedApp);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(TEST_ORG_ID);
+
+            assertSame(invokeGetOAuthAppDO(jwtValidator, TEST_CLIENT_ID_1), expectedApp,
+                    "Application should be resolved through the organization hierarchy.");
+            mockedOAuth2Util.verify(
+                    () -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID));
+            // The login-tenant lookup must not be used for an organization qualified request.
+            mockedOAuth2Util.verify(() -> OAuth2Util.getAppInformationByClientId(TEST_CLIENT_ID_1), never());
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId(previousOrgId);
+        }
+    }
+
+    /**
+     * Tenant qualified requests carry no application resident organization, and must keep resolving by tenant.
+     */
+    @Test
+    public void testGetOAuthAppDOResolvesByTenantWhenNotOrgQualified() throws Exception {
+
+        JWTValidator jwtValidator = getJWTValidator(new Properties());
+        OAuthAppDO expectedApp = new OAuthAppDO();
+        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
+        try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(TEST_CLIENT_ID_1))
+                    .thenReturn(expectedApp);
+
+            assertSame(invokeGetOAuthAppDO(jwtValidator, TEST_CLIENT_ID_1), expectedApp,
+                    "Application resolution must be unchanged when the request is not organization qualified.");
+            mockedOAuth2Util.verify(() -> OAuth2Util.getAppInformationFromOrgHierarchy(anyString(), anyString()),
+                    never());
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId(previousOrgId);
+        }
+    }
+
+    /**
+     * The signing algorithm lookup resolves the application as well, and must use the organization hierarchy on an
+     * organization qualified request for the same reason.
+     */
+    @Test
+    public void testGetConfiguredSigningAlgorithmResolvesThroughOrgHierarchy() throws Exception {
+
+        JWTValidator jwtValidator = getJWTValidator(new Properties());
+        OAuthAppDO expectedApp = new OAuthAppDO();
+        expectedApp.setTokenEndpointAuthSignatureAlgorithm(RS256);
+        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
+        try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
+            mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID))
+                    .thenReturn(expectedApp);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(TEST_ORG_ID);
+
+            assertEquals(invokeGetConfiguredSigningAlgorithm(jwtValidator, TEST_CLIENT_ID_1),
+                    Collections.singletonList(RS256),
+                    "Signing algorithm should be read from the application resolved via the organization hierarchy.");
+            mockedOAuth2Util.verify(
+                    () -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID));
+            mockedOAuth2Util.verify(
+                    () -> OAuth2Util.getAppInformationByClientId(anyString(), anyString()), never());
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId(previousOrgId);
+        }
+    }
+
+    private OAuthAppDO invokeGetOAuthAppDO(JWTValidator jwtValidator, String clientId) throws Exception {
+
+        return (OAuthAppDO) invokePrivate(jwtValidator, "getOAuthAppDO", clientId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> invokeGetConfiguredSigningAlgorithm(JWTValidator jwtValidator, String clientId)
+            throws Exception {
+
+        return (List<String>) invokePrivate(jwtValidator, "getConfiguredSigningAlgorithm", clientId);
+    }
+
+    private Object invokePrivate(JWTValidator jwtValidator, String methodName, String clientId) throws Exception {
+
+        Method method = JWTValidator.class.getDeclaredMethod(methodName, String.class);
+        method.setAccessible(true);
+        try {
+            return method.invoke(jwtValidator, clientId);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw e;
+        }
     }
 
         private void mockApplicationManagementService() throws Exception {

--- a/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt/src/test/java/org/wso2/carbon/identity/oauth2/token/handler/clientauth/jwt/validator/JWTValidatorTest.java
@@ -22,20 +22,26 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.codec.binary.Base64;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
@@ -79,6 +85,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_PAR_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_TOKEN_EP_URL;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.Constants.REJECT_BEFORE_IN_MINUTES;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.buildJWT;
 import static org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.util.JWTTestUtil.getJWTValidator;
@@ -101,6 +109,12 @@ public class JWTValidatorTest {
     public static final String TEST_SECRET_1 = "testSecret1";
     public static final String TEST_ORG_ID = "4dcedae8-5e1a-4812-abd0-4b034d40ad75";
     public static final String RS256 = "RS256";
+    public static final String ORG_QUALIFIED_TOKEN_EP =
+            "https://localhost:9443/t/carbon.super/o/" + TEST_ORG_ID + "/oauth2/token";
+    public static final String ORG_QUALIFIED_PAR_EP =
+            "https://localhost:9443/t/carbon.super/o/" + TEST_ORG_ID + "/oauth2/par";
+    public static final String TENANT_TOKEN_EP = "https://localhost:9443/oauth2/token";
+    private static final String PROP_TOKEN_EP = "OAuth2TokenEPUrl";
     public static final String VALID_ISSUER_VAL = "valid-issuer";
     public static final String VALID_ISSUER = "ValidIssuer";
     public static final String VALID_AUDIENCE = "ValidAudience";
@@ -132,6 +146,26 @@ public class JWTValidatorTest {
                     "aFr3vXKegooXrm58vCvg/J1nJapbhWiTDvgeNF5EhnLDNs04oBsOcjzrGDihv4F+Vl1yx/RelAwv\n" +
                     "W/bQM+jWUllR4Qpwx6R1mVy3pFRl0+4npUr17XOGEoP9Xm/5kMvsiNOTqryR5p3xEPBQcXBJES8K\n" +
                     "oQon6A==";
+
+    private String previousAppResidentOrgId;
+
+    /*
+     Tests that exercise organization qualified behaviour mutate the thread local carbon context. Snapshot it before
+     every test and restore it afterwards so nothing leaks between tests or depends on execution order.
+    */
+    @BeforeMethod
+    public void captureCarbonContext() {
+
+        previousAppResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getApplicationResidentOrganizationId();
+    }
+
+    @AfterMethod
+    public void restoreCarbonContext() {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setApplicationResidentOrganizationId(previousAppResidentOrgId);
+    }
 
     @BeforeClass
     public void setUp() throws Exception {
@@ -412,8 +446,6 @@ public class JWTValidatorTest {
 
         JWTValidator jwtValidator = getJWTValidator(new Properties());
         OAuthAppDO expectedApp = new OAuthAppDO();
-        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
         try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
             mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID))
                     .thenReturn(expectedApp);
@@ -425,9 +457,6 @@ public class JWTValidatorTest {
                     () -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID));
             // The login-tenant lookup must not be used for an organization qualified request.
             mockedOAuth2Util.verify(() -> OAuth2Util.getAppInformationByClientId(TEST_CLIENT_ID_1), never());
-        } finally {
-            PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .setApplicationResidentOrganizationId(previousOrgId);
         }
     }
 
@@ -439,8 +468,6 @@ public class JWTValidatorTest {
 
         JWTValidator jwtValidator = getJWTValidator(new Properties());
         OAuthAppDO expectedApp = new OAuthAppDO();
-        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
         try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
             mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(TEST_CLIENT_ID_1))
@@ -450,9 +477,6 @@ public class JWTValidatorTest {
                     "Application resolution must be unchanged when the request is not organization qualified.");
             mockedOAuth2Util.verify(() -> OAuth2Util.getAppInformationFromOrgHierarchy(anyString(), anyString()),
                     never());
-        } finally {
-            PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .setApplicationResidentOrganizationId(previousOrgId);
         }
     }
 
@@ -466,8 +490,6 @@ public class JWTValidatorTest {
         JWTValidator jwtValidator = getJWTValidator(new Properties());
         OAuthAppDO expectedApp = new OAuthAppDO();
         expectedApp.setTokenEndpointAuthSignatureAlgorithm(RS256);
-        String previousOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getApplicationResidentOrganizationId();
         try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class)) {
             mockedOAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID))
                     .thenReturn(expectedApp);
@@ -480,30 +502,86 @@ public class JWTValidatorTest {
                     () -> OAuth2Util.getAppInformationFromOrgHierarchy(TEST_CLIENT_ID_1, TEST_ORG_ID));
             mockedOAuth2Util.verify(
                     () -> OAuth2Util.getAppInformationByClientId(anyString(), anyString()), never());
-        } finally {
-            PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .setApplicationResidentOrganizationId(previousOrgId);
+        }
+    }
+
+    /**
+     * On an organization qualified request the endpoints derived from the application's own organization are not the
+     * ones a client calls. The organization qualified token and PAR endpoints, which the organization's discovery
+     * document advertises, must also be accepted as audiences, and the existing ones must keep working.
+     */
+    @Test
+    public void testGetValidAudiencesIncludesOrgQualifiedEndpoints() throws Exception {
+
+        JWTValidator jwtValidator = getJWTValidator(new Properties());
+        try (MockedStatic<IdentityProviderManager> ignored = mockResidentIdpWithOidcTokenEndpoint();
+             MockedStatic<ServiceURLBuilder> mockedUrlBuilder = mockStatic(ServiceURLBuilder.class)) {
+            ServiceURLBuilder builder = Mockito.mock(ServiceURLBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+            mockedUrlBuilder.when(ServiceURLBuilder::create).thenReturn(builder);
+            when(builder.addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL())
+                    .thenReturn(ORG_QUALIFIED_TOKEN_EP);
+            when(builder.addPath(OAUTH2_PAR_EP_URL).build().getAbsolutePublicURL())
+                    .thenReturn(ORG_QUALIFIED_PAR_EP);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(TEST_ORG_ID);
+
+            List<String> audiences = invokeGetValidAudiences(jwtValidator, SUPER_TENANT_DOMAIN_NAME,
+                    ORG_QUALIFIED_TOKEN_EP);
+
+            assertTrue(audiences.contains(ORG_QUALIFIED_TOKEN_EP),
+                    "The organization qualified token endpoint must be an accepted audience.");
+            assertTrue(audiences.contains(ORG_QUALIFIED_PAR_EP),
+                    "The organization qualified PAR endpoint must be an accepted audience.");
+        }
+    }
+
+    /**
+     * Without an application resident organization nothing extra is accepted, so the change cannot widen the
+     * audience set for ordinary tenant qualified requests.
+     */
+    @Test
+    public void testGetValidAudiencesUnchangedWhenNotOrgQualified() throws Exception {
+
+        JWTValidator jwtValidator = getJWTValidator(new Properties());
+        try (MockedStatic<IdentityProviderManager> ignored = mockResidentIdpWithOidcTokenEndpoint()) {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
+
+            List<String> audiences = invokeGetValidAudiences(jwtValidator, SUPER_TENANT_DOMAIN_NAME,
+                    ORG_QUALIFIED_TOKEN_EP);
+
+            assertFalse(audiences.contains(ORG_QUALIFIED_TOKEN_EP),
+                    "No organization qualified audience should be added outside an organization qualified request.");
         }
     }
 
     private OAuthAppDO invokeGetOAuthAppDO(JWTValidator jwtValidator, String clientId) throws Exception {
 
-        return (OAuthAppDO) invokePrivate(jwtValidator, "getOAuthAppDO", clientId);
+        return (OAuthAppDO) invokePrivate(jwtValidator, "getOAuthAppDO",
+                new Class<?>[]{String.class}, clientId);
     }
 
     @SuppressWarnings("unchecked")
     private List<String> invokeGetConfiguredSigningAlgorithm(JWTValidator jwtValidator, String clientId)
             throws Exception {
 
-        return (List<String>) invokePrivate(jwtValidator, "getConfiguredSigningAlgorithm", clientId);
+        return (List<String>) invokePrivate(jwtValidator, "getConfiguredSigningAlgorithm",
+                new Class<?>[]{String.class}, clientId);
     }
 
-    private Object invokePrivate(JWTValidator jwtValidator, String methodName, String clientId) throws Exception {
+    @SuppressWarnings("unchecked")
+    private List<String> invokeGetValidAudiences(JWTValidator jwtValidator, String tenantDomain, String requestUrl)
+            throws Exception {
 
-        Method method = JWTValidator.class.getDeclaredMethod(methodName, String.class);
+        return (List<String>) invokePrivate(jwtValidator, "getValidAudiences",
+                new Class<?>[]{String.class, String.class}, tenantDomain, requestUrl);
+    }
+
+    private Object invokePrivate(JWTValidator jwtValidator, String methodName, Class<?>[] signature, Object... args)
+            throws Exception {
+
+        Method method = JWTValidator.class.getDeclaredMethod(methodName, signature);
         method.setAccessible(true);
         try {
-            return method.invoke(jwtValidator, clientId);
+            return method.invoke(jwtValidator, args);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause instanceof Error) {
@@ -526,6 +604,30 @@ public class JWTValidatorTest {
                                 anyString())).thenReturn(mockedServiceProvider);
                 OAuth2ServiceComponentHolder.setApplicationMgtService(mockedApplicationManagementService);
         }
+
+    /**
+     * Resident IdP carrying an OIDC federated authenticator with a token endpoint, which is what
+     * {@code getValidAudiences} reads to build the base audience list.
+     */
+    private MockedStatic<IdentityProviderManager> mockResidentIdpWithOidcTokenEndpoint() throws Exception {
+
+        Property tokenEndpointProperty = new Property();
+        tokenEndpointProperty.setName(PROP_TOKEN_EP);
+        tokenEndpointProperty.setValue(TENANT_TOKEN_EP);
+        FederatedAuthenticatorConfig oidcConfig = new FederatedAuthenticatorConfig();
+        oidcConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
+        oidcConfig.setProperties(new Property[]{tokenEndpointProperty});
+
+        IdentityProvider residentIdp = Mockito.mock(IdentityProvider.class);
+        when(residentIdp.getFederatedAuthenticatorConfigs())
+                .thenReturn(new FederatedAuthenticatorConfig[]{oidcConfig});
+        IdentityProviderManager idpManager = Mockito.mock(IdentityProviderManager.class);
+        when(idpManager.getResidentIdP(anyString())).thenReturn(residentIdp);
+
+        MockedStatic<IdentityProviderManager> mockedIdentityProviderManager = mockStatic(IdentityProviderManager.class);
+        mockedIdentityProviderManager.when(IdentityProviderManager::getInstance).thenReturn(idpManager);
+        return mockedIdentityProviderManager;
+    }
 
         private MockedStatic<IdentityProviderManager> mockIdentityProviderManager() throws Exception {
 


### PR DESCRIPTION
### Limitation

Private key JWT client authentication fails on organization qualified token requests /t/{tenant}/o/{orgId}/oauth2/token for an application residing in a sub organization. 

The application is resolved against the login tenant, which is the parent organization, so the lookup misses and the request fails with below error.
```
Error while retrieving OAuth application with provided JWT information with subject '<clientId>'.
```

### Proposed Fix

Resolve the application through the organization hierarchy when an application resident organization is set on the carbon context, in both places `JWTValidator` looks the application up. This mirrors what `BasicAuthClientAuthenticator` already does, which is why `client_secret_basic` works on the same endpoint. Behaviour for non organization qualified requests is unchanged.

### Tested flows.

1. `/t/{tenant-domain}/oauth2/token`    // Existing working approach for sub-orgs.
2. `/t/{tenant}/o/{orgId}/oauth2/token` // Proposed improvement.
3. Changing issuer reflects for the final token.  // Verified for case 2. For case 1 it didn't work.